### PR TITLE
Fixed another bug

### DIFF
--- a/TCSlackbot.Logic/Authentication/SecretManager.cs
+++ b/TCSlackbot.Logic/Authentication/SecretManager.cs
@@ -38,15 +38,21 @@ namespace TCSlackbot.Logic
                 return;
             }
 
+            // Delete the secret in the key vault
+            //
             try
             {
                 await keyVaultClient.DeleteSecretAsync(KeyVaultEndpoint, key);
-
             }
             catch (KeyVaultErrorException ex)
             {
                 Console.WriteLine("\n\nError:" + ex.Message);
             }
+
+            // Delete it locally (needed in case the secret cannot be deleted). If the above statement fails, this will save it. 
+            // Without this, the user may have an invalid refresh token stored in the key vault and can't use the bot anymore.
+            // 
+            _configuration[key] = null;
 
             // Reload the configuration because we added a new secret
             ((IConfigurationRoot)_configuration).Reload();

--- a/TCSlackbot.Logic/Authentication/TokenManager.cs
+++ b/TCSlackbot.Logic/Authentication/TokenManager.cs
@@ -64,7 +64,9 @@ namespace TCSlackbot.Logic.Utils
             }
             catch (LoggedOutException)
             {
-                return BotResponses.ErrorLoggedOut;
+                // Throw new exception, so you don't have to rethrow the catched exception (this would change the stack information)
+                // 
+                throw new LoggedOutException();
             }
         }
 


### PR DESCRIPTION
The users would not get logged out, if their refresh token could not be deleted. Thus it also needs to be deleted locally, which allows the user to login again and thus overwrite the existing refresh token.